### PR TITLE
rm wave and exp transmission loss variant

### DIFF
--- a/src/nos/data/__init__.py
+++ b/src/nos/data/__init__.py
@@ -1,13 +1,9 @@
 from .transmission_loss import (
     TLDataset,
     TLDatasetCompact,
-    TLDatasetCompactExp,
-    TLDatasetCompactWave,
 )
 
 __all__ = [
     "TLDataset",
     "TLDatasetCompact",
-    "TLDatasetCompactExp",
-    "TLDatasetCompactWave",
 ]

--- a/src/nos/data/transmission_loss.py
+++ b/src/nos/data/transmission_loss.py
@@ -1,6 +1,5 @@
 import pathlib
 from typing import (
-    Callable,
     Dict,
 )
 
@@ -145,88 +144,6 @@ class TLDatasetCompact(OperatorDataset):
         u = x
         y = torch.tensor(df["frequencies"].tolist()).reshape(len(df), -1, 1)
         v = torch.tensor(df["transmission_losses"]).unsqueeze(1).reshape(len(df), -1, 1)
-
-        transformations = get_transformations(x, u, y, v)
-
-        super().__init__(x, u, y, v, **transformations)
-
-
-def simple_sine_encoding(u, x):
-    vals = torch.einsum("abc,ade->adc", u, x)  # different modes for the properties
-    # min-max scale all values
-    min_vals, _ = torch.min(vals.view(-1, vals.size(-1)), dim=0)
-    max_vals, _ = torch.max(vals.view(-1, vals.size(-1)), dim=0)
-    vals = ((vals - min_vals) / (max_vals - min_vals) + 1) * torch.pi
-
-    x_min = torch.min(x)
-    x_max = torch.max(x)
-    x_scaled = ((x - x_min) / (x_max - x_min) - 0.5) * 2
-
-    return torch.sin(x_scaled * vals)
-
-
-def gaussian_modulated_sine_encoding(u, x):
-    # leads to massive overfitting
-    alpha = 5
-
-    min_u, _ = torch.min(u.view(-1, u.size(-1)), dim=0)
-    max_u, _ = torch.max(u.view(-1, u.size(-1)), dim=0)
-    u_scaled = ((u - min_u) / (max_u - min_u) + 1) * 2  # [1, 2]
-
-    min_x, _ = torch.min(x.view(-1, x.size(-1)), dim=0)
-    max_x, _ = torch.max(x.view(-1, x.size(-1)), dim=0)
-    x_scaled = ((x - min_x) / (max_x - min_x) - 0.5) * 2  # [-1, 1]
-
-    return torch.exp(-alpha * x_scaled**2) * torch.sin(4 * np.pi * u_scaled * (x_scaled + 1))
-
-
-class TLDatasetCompactWave(OperatorDataset):
-    """Transmission loss dataset, for use with FNO."""
-
-    def __init__(self, path: pathlib.Path, n_samples: int = -1, wave_encoding: Callable = simple_sine_encoding):
-        df = get_tl_compact(path, n_samples)
-
-        x = torch.tensor(df["frequencies"].tolist()).reshape(len(df), -1, 1)
-        u = torch.stack(
-            [
-                torch.tensor(df["radius"].tolist()),
-                torch.tensor(df["inner_radius"].tolist()),
-                torch.tensor(df["gap_width"].tolist()),
-            ],
-            dim=1,
-        ).reshape(len(df), 1, 3)
-        y = torch.tensor(df["frequencies"].tolist()).reshape(len(df), -1, 1)
-        v = torch.tensor(df["transmission_losses"]).unsqueeze(1).reshape(len(df), -1, 1)
-
-        # apply wave encoding
-        u = wave_encoding(u, x)
-
-        transformations = get_transformations(x, u, y, v)
-
-        super().__init__(x, u, y, v, **transformations)
-
-
-class TLDatasetCompactExp(OperatorDataset):
-    """Transmission loss dataset, with bigger evaluation space."""
-
-    def __init__(self, path: pathlib.Path, n_samples: int = -1):
-        df = get_tl_compact(path, n_samples)
-
-        x = torch.stack(
-            [
-                torch.tensor(df["radius"].tolist()),
-                torch.tensor(df["inner_radius"].tolist()),
-                torch.tensor(df["gap_width"].tolist()),
-            ],
-            dim=1,
-        ).reshape(len(df), 1, 3)
-        u = x
-        y = torch.tensor(df["frequencies"].tolist()).reshape(len(df), -1, 1)
-        v = torch.tensor(df["transmission_losses"]).unsqueeze(1).reshape(len(df), -1, 1)
-
-        # exp part
-        v = torch.clamp(v, max=0.0)  # clamp unphysical values over zero to zero
-        v = torch.pow(v, 10)
 
         transformations = get_transformations(x, u, y, v)
 

--- a/tests/data/test_transmission_loss.py
+++ b/tests/data/test_transmission_loss.py
@@ -1,8 +1,6 @@
 from nos.data import (
     TLDataset,
     TLDatasetCompact,
-    TLDatasetCompactExp,
-    TLDatasetCompactWave,
 )
 
 
@@ -29,36 +27,6 @@ class TestTLDatasetCompact:
 
     def test_has_populated_tensors(self, tl_csv_file):
         dataset = TLDatasetCompact(tl_csv_file)
-
-        assert dataset.x.nelement() > 0
-        assert dataset.u.nelement() > 0
-        assert dataset.y.nelement() > 0
-        assert dataset.v.nelement() > 0
-
-
-class TestTLDatasetCompactExp:
-    def test_can_initialize(self, tl_csv_file):
-        dataset = TLDatasetCompactExp(tl_csv_file)
-
-        assert isinstance(dataset, TLDatasetCompactExp)
-
-    def test_has_populated_tensors(self, tl_csv_file):
-        dataset = TLDatasetCompactExp(tl_csv_file)
-
-        assert dataset.x.nelement() > 0
-        assert dataset.u.nelement() > 0
-        assert dataset.y.nelement() > 0
-        assert dataset.v.nelement() > 0
-
-
-class TestTLDatasetCompactWave:
-    def test_can_initialize(self, tl_csv_file):
-        dataset = TLDatasetCompactWave(tl_csv_file)
-
-        assert isinstance(dataset, TLDatasetCompactWave)
-
-    def test_has_populated_tensors(self, tl_csv_file):
-        dataset = TLDatasetCompactWave(tl_csv_file)
 
         assert dataset.x.nelement() > 0
         assert dataset.u.nelement() > 0


### PR DESCRIPTION
# Description

Removes the wave and exp variant of the transmission loss dataset. The encoding performed by these datasets should either be performed during preprocessing or in the network itself.

# Which issue does this PR tackle?

- The exp and wave variant of the transmission loss dataset are hard to maintain.
- Both operations performed by these variants of the compact dataset should be performed in a different place and are not responsibility of the dataset.

# How does it solve the problem?

- Removes exp and wave variant of the transmission loss dataset.

# How are the changes tested?

- Unit-tests:
  - Old unit tests run without new errors.

# Checklist

- [ ] Documentation
    - [ ] All new features include documentation
    - [ ] README is updated
- [ ] CI/CD passes all pipeline checks
- [ ] Post Merge
    - [ ] Delete the feature branch (if applicable).
    - [ ] Update related issues or project boards.
