### PR TITLE
Fix: Transforms new Operatordataset

### DIFF
--- a/src/nos/transforms/median_peak_scaler_without_shift.py
+++ b/src/nos/transforms/median_peak_scaler_without_shift.py
@@ -11,9 +11,11 @@ class MedianPeak(Transform):
         src: torch.Tensor,
     ):
         super().__init__()
+
+        src = src.transpose(1, -1)
         peaks, _ = torch.max(torch.abs(src), dim=1, keepdim=True)
         medians, _ = torch.median(peaks, dim=0, keepdim=True)
-        self.medians = nn.Parameter(medians)
+        self.medians = nn.Parameter(medians.transpose(1, -1))
 
     def forward(self, tensor: torch.Tensor) -> torch.Tensor:
         return tensor / self.medians

--- a/tests/transforms/test_center_quantile_scaler.py
+++ b/tests/transforms/test_center_quantile_scaler.py
@@ -6,8 +6,8 @@ from nos.transforms import (
 
 
 class TestCenterQuantileScaler:
-    x = torch.rand(7, 89, 13)
-    y = torch.rand(17, 97, 13)
+    x = torch.rand(7, 13, 89)
+    y = torch.rand(17, 13, 97)
 
     def test_can_init(self):
         transform = CenterQuantileScaler(self.x)

--- a/tests/transforms/test_median_peak_scaler_without_shift.py
+++ b/tests/transforms/test_median_peak_scaler_without_shift.py
@@ -6,8 +6,8 @@ from nos.transforms import (
 
 
 class TestMedianPeakScaler:
-    x = torch.rand(7, 11, 13)
-    y = torch.rand(17, 19, 13)
+    x = torch.rand(7, 13, 11)
+    y = torch.rand(17, 13, 19)
 
     def test_can_initialize(self):
         transform = MedianPeak(self.x)

--- a/tests/transforms/test_min_max_scaler.py
+++ b/tests/transforms/test_min_max_scaler.py
@@ -1,0 +1,42 @@
+import torch
+
+from nos.transforms import (
+    MinMaxScale,
+)
+
+
+class TestMinMaxScale:
+    def test_can_initialize(self):
+        scaler = MinMaxScale(torch.zeros(1, 2, 3), torch.ones(1, 2, 3))
+        assert isinstance(scaler, MinMaxScale)
+
+    def test_can_forward(self):
+        scaler = MinMaxScale(torch.zeros(2, 2), torch.ones(2, 2))
+
+        x = torch.rand(2, 2)
+
+        out = scaler(x)
+
+        assert isinstance(out, torch.Tensor)
+
+    def test_forward_correct(self):
+        scaler = MinMaxScale(-torch.ones(1, 2, 1), 2 * torch.ones(1, 2, 1))
+
+        x = torch.linspace(-1, 2, 30)
+        x = x.reshape(1, 2, -1)
+
+        out = scaler(x)
+
+        assert torch.all(out >= -1.0)
+        assert torch.all(out <= 1.0)
+        assert torch.sum(torch.isclose(out, -torch.ones(out.shape))) == 1
+        assert torch.sum(torch.isclose(out, torch.ones(out.shape))) == 1
+
+    def test_can_undo(self):
+        scaler = MinMaxScale(-torch.ones(1, 2, 1), 2 * torch.ones(1, 2, 1))
+
+        x = torch.linspace(-1, 2, 30)
+
+        out = scaler.undo(x)
+
+        assert isinstance(out, torch.Tensor)

--- a/tests/transforms/test_quantile_scaler.py
+++ b/tests/transforms/test_quantile_scaler.py
@@ -6,8 +6,8 @@ from nos.transforms import (
 
 
 class TestQuantileScaler:
-    x = torch.rand(7, 11, 13)
-    y = torch.rand(17, 19, 13)
+    x = torch.rand(7, 13, 11)
+    y = torch.rand(17, 13, 19)
 
     def test_can_init(self):
         transform = QuantileScaler(self.x)


### PR DESCRIPTION
# Description

The new implementation of `OperatorDataset` of the continuiti package assumes that the shape is (#obs, #dim, ....), while the current implementation assumes (#obs, ..., #dim). This PR fixes the transforms for this change.

# Which issue does this PR tackle?

- Transfroms do not conform to new datasets structure.

# How are the changes tested?

- Unit-tests:
  - Add test for minmax scaler.
  - Adapt tests for transforms.
  - No new errors.
  
# Checklist

- [x] Documentation
    - [ ] All new features include documentation
    - [ ] README is updated
- [x] CI/CD passes all pipeline checks
- [ ] Post Merge
    - [ ] Delete the feature branch (if applicable).
    - [ ] Update related issues or project boards.
