### PR TITLE
Fix: Quantile Scaler use in dataloader

### DIFF
--- a/src/nos/transforms/quantile_scaler.py
+++ b/src/nos/transforms/quantile_scaler.py
@@ -129,7 +129,7 @@ class QuantileScaler(Transform):
         Returns:
             The transformed tensor, scaled to the target distribution.
         """
-        tensor = tensor.transpose(1, -1)
+        tensor = tensor.transpose(0, 1)
         indices = self._get_scaling_indices(tensor, self.quantile_points)
         # Scale input tensor to the unit interval based on source quantiles
         p_min = self.quantile_points[indices].view(tensor.shape)
@@ -143,7 +143,7 @@ class QuantileScaler(Transform):
         out = out * delta_t
         out = out + p_t_min
 
-        return out.transpose(1, -1)
+        return out.transpose(0, 1)
 
     def undo(self, tensor: torch.Tensor) -> torch.Tensor:
         """Reverses the transformation applied by the forward method, mapping the tensor back to its original
@@ -155,7 +155,7 @@ class QuantileScaler(Transform):
         Returns:
             The tensor with the quantile scaling transformation reversed according to the src distribution.
         """
-        tensor = tensor.transpose(1, -1)
+        tensor = tensor.transpose(0, 1)
         indices = self._get_scaling_indices(tensor, self.target_quantile_points)
 
         # Scale input tensor to the unit interval based on the target distribution
@@ -170,4 +170,4 @@ class QuantileScaler(Transform):
         out = out * delta
         out = out + p_min
 
-        return out.transpose(1, -1)
+        return out.transpose(0, 1)

--- a/tests/transforms/test_quantile_scaler.py
+++ b/tests/transforms/test_quantile_scaler.py
@@ -6,8 +6,8 @@ from nos.transforms import (
 
 
 class TestQuantileScaler:
-    x = torch.rand(7, 13, 11)
-    y = torch.rand(17, 13, 19)
+    x = torch.rand(45, 13, 11)
+    y = torch.rand(13, 19)
 
     def test_can_init(self):
         transform = QuantileScaler(self.x)


### PR DESCRIPTION
# Description

The quantile scaler should be used together with a torch dataloader. While the initialization is performed on the entire dataset, the forward pass is performed on single observation.

# How are the changes tested?

- Unit-tests:
  - Adapted to use with dataloader.
  

# Checklist

- [x] Documentation
    - [ ] All new features include documentation
    - [ ] README is updated
- [x] CI/CD passes all pipeline checks
- [ ] Post Merge
    - [ ] Delete the feature branch (if applicable).
    - [ ] Update related issues or project boards.
